### PR TITLE
Move forms into Siemens-IX modals

### DIFF
--- a/frontend-app/src/components/ClientList.tsx
+++ b/frontend-app/src/components/ClientList.tsx
@@ -1,12 +1,20 @@
 // src/components/ClientList.tsx
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, useRef } from 'react'
 import { useGetClients, useCreateClient } from '../api/fastAPI'
 import type { ClientCreate, ClientResponse } from '../api/fastAPI.schemas'
-import  { IxInput, IxButton } from '@siemens/ix-react'
+import  {
+  IxInput,
+  IxButton,
+  IxModal,
+  IxModalHeader,
+  IxModalContent,
+  IxModalFooter,
+} from '@siemens/ix-react'
 
 export function ClientList() {
   const { data, refetch } = useGetClients()
   const createClient = useCreateClient()
+  const modalRef = useRef<HTMLIxModalElement>(null)
   const [form, setForm] = useState<ClientCreate>({
     name: '',
     score: 10,
@@ -26,6 +34,7 @@ export function ClientList() {
       {
         onSuccess: () => {
           setForm({ name: '', score: 10})
+          modalRef.current?.closeModal()
           refetch()
         },
       },
@@ -36,21 +45,32 @@ export function ClientList() {
 
   return (
     <>
-    <form onSubmit={handleSubmit} style={{ marginTop: '1rem'}}>
-      <IxInput
-        placeholder="Nombre"
-        value={form.name}
-        onInput={handleChange('name')}
-      />
-      <IxInput
-        placeholder="Calificacion"
-        value={form.score.toFixed(0)}
-        onInput={handleChange('score')}
-      />
-      <IxButton type="submit" style={{ marginTop: '0.5rem'}}>
-        Crear cliente
+      <IxButton onClick={() => modalRef.current?.showModal()} style={{ marginTop: '1rem'}}>
+        Nuevo cliente
       </IxButton>
-    </form>
+      <IxModal ref={modalRef} closeOnBackdropClick closeOnEscape>
+        <IxModalHeader>Crear cliente</IxModalHeader>
+        <IxModalContent>
+          <form id="client-form" onSubmit={handleSubmit}>
+            <IxInput
+              placeholder="Nombre"
+              value={form.name}
+              onInput={handleChange('name')}
+            />
+            <IxInput
+              placeholder="Calificacion"
+              value={form.score.toFixed(0)}
+              onInput={handleChange('score')}
+            />
+          </form>
+        </IxModalContent>
+        <IxModalFooter>
+          <IxButton onClick={() => modalRef.current?.dismissModal()}>Cancelar</IxButton>
+          <IxButton type="submit" form="client-form" style={{ marginLeft: '0.5rem'}}>
+            Crear
+          </IxButton>
+        </IxModalFooter>
+      </IxModal>
       <table className="ix-table ix-table-striped">
         <thead>
           <tr>

--- a/frontend-app/src/components/ProjectList.tsx
+++ b/frontend-app/src/components/ProjectList.tsx
@@ -1,11 +1,19 @@
-import React, { useState } from 'react'
+import React, { useState, useRef } from 'react'
 import { useGetProjects, useCreateProject } from '../api/fastAPI'
 import type { ProjectCreate } from '../api/fastAPI.schemas'
-import { IxInput, IxButton } from '@siemens/ix-react'
+import {
+  IxInput,
+  IxButton,
+  IxModal,
+  IxModalHeader,
+  IxModalContent,
+  IxModalFooter,
+} from '@siemens/ix-react'
 
 export function ProjectList() {
   const { data, refetch } = useGetProjects()
   const createProject = useCreateProject()
+  const modalRef = useRef<HTMLIxModalElement>(null)
   const [form, setForm] = useState<ProjectCreate>({
     name: '',
     client: '',
@@ -26,6 +34,7 @@ export function ProjectList() {
       {
         onSuccess: () => {
           setForm({ name: '', client: '', responsible: '' })
+          modalRef.current?.closeModal()
           refetch()
         },
       },
@@ -36,26 +45,37 @@ export function ProjectList() {
 
   return (
     <>
-      <form onSubmit={handleSubmit} style={{ marginTop: '1rem' }}>
-        <IxInput
-          placeholder="Nombre"
-          value={form.name}
-          onInput={handleChange('name')}
-        />
-        <IxInput
-          placeholder="Cliente"
-          value={form.client}
-          onInput={handleChange('client')}
-        />
-        <IxInput
-          placeholder="Responsable"
-          value={form.responsible}
-          onInput={handleChange('responsible')}
-        />
-        <IxButton type="submit" style={{ marginTop: '0.5rem' }}>
-          Crear proyecto
-        </IxButton>
-      </form>
+      <IxButton onClick={() => modalRef.current?.showModal()} style={{ marginTop: '1rem' }}>
+        Nuevo proyecto
+      </IxButton>
+      <IxModal ref={modalRef} closeOnBackdropClick closeOnEscape>
+        <IxModalHeader>Crear proyecto</IxModalHeader>
+        <IxModalContent>
+          <form id="project-form" onSubmit={handleSubmit}>
+            <IxInput
+              placeholder="Nombre"
+              value={form.name}
+              onInput={handleChange('name')}
+            />
+            <IxInput
+              placeholder="Cliente"
+              value={form.client}
+              onInput={handleChange('client')}
+            />
+            <IxInput
+              placeholder="Responsable"
+              value={form.responsible}
+              onInput={handleChange('responsible')}
+            />
+          </form>
+        </IxModalContent>
+        <IxModalFooter>
+          <IxButton onClick={() => modalRef.current?.dismissModal()}>Cancelar</IxButton>
+          <IxButton type="submit" form="project-form" style={{ marginLeft: '0.5rem' }}>
+            Crear
+          </IxButton>
+        </IxModalFooter>
+      </IxModal>
       <table className="ix-table ix-table-striped">
         <thead>
           <tr>
@@ -79,3 +99,4 @@ export function ProjectList() {
     </>
   )
 }
+

--- a/frontend-app/src/components/WorkerList.tsx
+++ b/frontend-app/src/components/WorkerList.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import {
   useGetWorkers,
   useCreateWorker,
@@ -11,11 +11,16 @@ import {
   IxLayoutAuto,
   IxInput,
   IxButton,
+  IxModal,
+  IxModalHeader,
+  IxModalContent,
+  IxModalFooter,
 } from '@siemens/ix-react'
 
 export function WorkerList() {
   const { data, refetch } = useGetWorkers()
   const createWorker = useCreateWorker()
+  const modalRef = useRef<HTMLIxModalElement>(null)
   const [form, setForm] = useState<WorkerCreate>({
     name: '',
     parental_surname: '',
@@ -36,6 +41,7 @@ export function WorkerList() {
       {
         onSuccess: () => {
           setForm({ name: '', parental_surname: '', maternal_surname: '' })
+          modalRef.current?.closeModal()
           refetch()
         },
       },
@@ -46,26 +52,37 @@ export function WorkerList() {
 
   return (
     <>
-      <form onSubmit={handleSubmit} style={{ marginTop: '1rem' }}>
-        <IxInput
-          placeholder="Nombre"
-          value={form.name}
-          onInput={handleChange('name')}
-        />
-        <IxInput
-          placeholder="Apellido paterno"
-          value={form.parental_surname}
-          onInput={handleChange('parental_surname')}
-        />
-        <IxInput
-          placeholder="Apellido materno"
-          value={form.maternal_surname}
-          onInput={handleChange('maternal_surname')}
-        />
-        <IxButton type="submit" style={{ marginTop: '0.5rem' }}>
-          Crear trabajador
-        </IxButton>
-      </form>
+      <IxButton onClick={() => modalRef.current?.showModal()} style={{ marginTop: '1rem' }}>
+        Nuevo trabajador
+      </IxButton>
+      <IxModal ref={modalRef} closeOnBackdropClick closeOnEscape>
+        <IxModalHeader>Crear trabajador</IxModalHeader>
+        <IxModalContent>
+          <form id="worker-form" onSubmit={handleSubmit}>
+            <IxInput
+              placeholder="Nombre"
+              value={form.name}
+              onInput={handleChange('name')}
+            />
+            <IxInput
+              placeholder="Apellido paterno"
+              value={form.parental_surname}
+              onInput={handleChange('parental_surname')}
+            />
+            <IxInput
+              placeholder="Apellido materno"
+              value={form.maternal_surname}
+              onInput={handleChange('maternal_surname')}
+            />
+          </form>
+        </IxModalContent>
+        <IxModalFooter>
+          <IxButton onClick={() => modalRef.current?.dismissModal()}>Cancelar</IxButton>
+          <IxButton type="submit" form="worker-form" style={{ marginLeft: '0.5rem' }}>
+            Crear
+          </IxButton>
+        </IxModalFooter>
+      </IxModal>
       <IxLayoutAuto
         layout={[
           { minWidth: '0', columns: 1 },


### PR DESCRIPTION
## Summary
- open add forms in Siemens-IX modals for workers, clients and projects

## Testing
- `npm ci`
- `npm run lint` *(fails: '@typescript-eslint/no-unused-vars' and others)*

------
https://chatgpt.com/codex/tasks/task_b_6860e9a274288320a6bd6e075d6f5698