### PR TITLE
Relate projects with clients and workers

### DIFF
--- a/backend-app/api/projects.py
+++ b/backend-app/api/projects.py
@@ -16,5 +16,5 @@ def create_project(project: ProjectCreate, session: Session = Depends(get_sessio
 @router.get("/", response_model=list[ProjectResponse], operation_id="getProjects")
 def get_projects(session: Session = Depends(get_session)):
     statement = select(Project)
-    result = session.exec(statement)
+    result = session.exec(statement).all()
     return result

--- a/backend-app/models/client.py
+++ b/backend-app/models/client.py
@@ -1,6 +1,9 @@
 from sqlmodel import Field, SQLModel, Relationship
-from typing import Optional, List
+from typing import Optional, List, TYPE_CHECKING
 from datetime import datetime
+
+if TYPE_CHECKING:
+    from .project import Project
 
 class ClientBase(SQLModel):
     name: str
@@ -11,6 +14,7 @@ class ClientBase(SQLModel):
 
 class Client(ClientBase, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
+    projects: List["Project"] = Relationship(back_populates="client")
 
 class ClientCreate(ClientBase):
     pass

--- a/backend-app/models/project.py
+++ b/backend-app/models/project.py
@@ -1,16 +1,22 @@
-from sqlmodel import Field, SQLModel
-from typing import Optional
+from sqlmodel import Field, SQLModel, Relationship
+from typing import Optional, TYPE_CHECKING
 from datetime import datetime
+
+if TYPE_CHECKING:
+    from .client import Client
+    from .worker import Worker
 
 class ProjectBase(SQLModel):
     name: str
-    client: str
-    responsible: str
+    client_id: int | None = Field(default=None, foreign_key="client.id")
+    worker_id: int | None = Field(default=None, foreign_key="worker.id")
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
 
 class Project(ProjectBase, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
+    client: Optional["Client"] = Relationship(back_populates="projects")
+    worker: Optional["Worker"] = Relationship(back_populates="projects")
 
 class ProjectCreate(ProjectBase):
     pass
@@ -20,5 +26,5 @@ class ProjectResponse(ProjectBase):
 
 class ProjectUpdate(SQLModel):
     name: Optional[str] = None
-    client: Optional[str] = None
-    responsible: Optional[str] = None
+    client_id: Optional[int] = None
+    worker_id: Optional[int] = None

--- a/backend-app/models/worker.py
+++ b/backend-app/models/worker.py
@@ -1,6 +1,9 @@
 from sqlmodel import Field, SQLModel, Relationship
-from typing import Optional, List
+from typing import Optional, List, TYPE_CHECKING
 from datetime import datetime
+
+if TYPE_CHECKING:
+    from .project import Project
 
 class WorkerBase(SQLModel):
     name: str
@@ -11,6 +14,7 @@ class WorkerBase(SQLModel):
 
 class Worker(WorkerBase, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
+    projects: List["Project"] = Relationship(back_populates="worker")
 
 class WorkerCreate(WorkerBase):
     pass

--- a/frontend-app/openapi.json
+++ b/frontend-app/openapi.json
@@ -1,1 +1,661 @@
-{"openapi":"3.1.0","info":{"title":"FastAPI","version":"0.1.0"},"paths":{"/api/dev/create-db-and-tables":{"post":{"tags":["Development"],"summary":"Create Db And Tables","operationId":"create_db_and_tables_api_dev_create_db_and_tables_post","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}}}}},"/api/workers/":{"get":{"tags":["Workers"],"summary":"Get Workers","operationId":"getWorkers","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"items":{"$ref":"#/components/schemas/WorkerResponse"},"type":"array","title":"Response Getworkers"}}}}}},"post":{"tags":["Workers"],"summary":"Create Worker","operationId":"createWorker","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/WorkerCreate"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/WorkerResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/workers/{worker_id}":{"get":{"tags":["Workers"],"summary":"Get Worker","operationId":"getWorker","parameters":[{"name":"worker_id","in":"path","required":true,"schema":{"type":"integer","title":"Worker Id"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/WorkerResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"put":{"tags":["Workers"],"summary":"Update Worker","operationId":"updateWorker","parameters":[{"name":"worker_id","in":"path","required":true,"schema":{"type":"integer","title":"Worker Id"}}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/WorkerUpdate"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/WorkerResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"delete":{"tags":["Workers"],"summary":"Delete Worker","operationId":"deleteWorker","parameters":[{"name":"worker_id","in":"path","required":true,"schema":{"type":"integer","title":"Worker Id"}}],"responses":{"204":{"description":"Successful Response"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/clients/":{"get":{"tags":["Clients"],"summary":"Get Clients","operationId":"getClients","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"items":{"$ref":"#/components/schemas/ClientResponse"},"type":"array","title":"Response Getclients"}}}}}},"post":{"tags":["Clients"],"summary":"Create Client","operationId":"createClient","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/ClientCreate"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/ClientResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/projects/":{"get":{"tags":["Projects"],"summary":"Get Projects","operationId":"getProjects","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"items":{"$ref":"#/components/schemas/ProjectResponse"},"type":"array","title":"Response Getprojects"}}}}}},"post":{"tags":["Projects"],"summary":"Create Project","operationId":"createProject","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/ProjectCreate"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/ProjectResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}}},"components":{"schemas":{"ClientCreate":{"properties":{"name":{"type":"string","title":"Name"},"score":{"type":"integer","title":"Score"},"create_at":{"type":"string","format":"date-time","title":"Create At"},"updated_at":{"type":"string","format":"date-time","title":"Updated At"}},"type":"object","required":["name","score"],"title":"ClientCreate"},"ClientResponse":{"properties":{"name":{"type":"string","title":"Name"},"score":{"type":"integer","title":"Score"},"create_at":{"type":"string","format":"date-time","title":"Create At"},"updated_at":{"type":"string","format":"date-time","title":"Updated At"},"id":{"type":"integer","title":"Id"}},"type":"object","required":["name","score","id"],"title":"ClientResponse"},"HTTPValidationError":{"properties":{"detail":{"items":{"$ref":"#/components/schemas/ValidationError"},"type":"array","title":"Detail"}},"type":"object","title":"HTTPValidationError"},"ValidationError":{"properties":{"loc":{"items":{"anyOf":[{"type":"string"},{"type":"integer"}]},"type":"array","title":"Location"},"msg":{"type":"string","title":"Message"},"type":{"type":"string","title":"Error Type"}},"type":"object","required":["loc","msg","type"],"title":"ValidationError"},"WorkerCreate":{"properties":{"name":{"type":"string","title":"Name"},"parental_surname":{"type":"string","title":"Parental Surname"},"maternal_surname":{"type":"string","title":"Maternal Surname"},"created_at":{"type":"string","format":"date-time","title":"Created At"},"updated_at":{"type":"string","format":"date-time","title":"Updated At"}},"type":"object","required":["name","parental_surname","maternal_surname"],"title":"WorkerCreate"},"WorkerResponse":{"properties":{"name":{"type":"string","title":"Name"},"parental_surname":{"type":"string","title":"Parental Surname"},"maternal_surname":{"type":"string","title":"Maternal Surname"},"created_at":{"type":"string","format":"date-time","title":"Created At"},"updated_at":{"type":"string","format":"date-time","title":"Updated At"},"id":{"type":"integer","title":"Id"}},"type":"object","required":["name","parental_surname","maternal_surname","id"],"title":"WorkerResponse"},"WorkerUpdate":{"properties":{"name":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Name"},"parental_surname":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Parental Surname"},"maternal_surname":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Maternal Surname"}},"type":"object","title":"WorkerUpdate"},"ProjectCreate":{"properties":{"name":{"type":"string","title":"Name"},"client":{"type":"string","title":"Client"},"responsible":{"type":"string","title":"Responsible"},"created_at":{"type":"string","format":"date-time","title":"Created At"},"updated_at":{"type":"string","format":"date-time","title":"Updated At"}},"type":"object","required":["name","client","responsible"],"title":"ProjectCreate"},"ProjectResponse":{"properties":{"name":{"type":"string","title":"Name"},"client":{"type":"string","title":"Client"},"responsible":{"type":"string","title":"Responsible"},"created_at":{"type":"string","format":"date-time","title":"Created At"},"updated_at":{"type":"string","format":"date-time","title":"Updated At"},"id":{"type":"integer","title":"Id"}},"type":"object","required":["name","client","responsible","id"],"title":"ProjectResponse"},"ProjectUpdate":{"properties":{"name":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Name"},"client":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Client"},"responsible":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Responsible"}},"type":"object","title":"ProjectUpdate"}}}}
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "FastAPI",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/api/dev/create-db-and-tables": {
+      "post": {
+        "tags": [
+          "Development"
+        ],
+        "summary": "Create Db And Tables",
+        "operationId": "create_db_and_tables_api_dev_create_db_and_tables_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workers/": {
+      "get": {
+        "tags": [
+          "Workers"
+        ],
+        "summary": "Get Workers",
+        "operationId": "getWorkers",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/WorkerResponse"
+                  },
+                  "type": "array",
+                  "title": "Response Getworkers"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Workers"
+        ],
+        "summary": "Create Worker",
+        "operationId": "createWorker",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkerCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkerResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workers/{worker_id}": {
+      "get": {
+        "tags": [
+          "Workers"
+        ],
+        "summary": "Get Worker",
+        "operationId": "getWorker",
+        "parameters": [
+          {
+            "name": "worker_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Worker Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkerResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Workers"
+        ],
+        "summary": "Update Worker",
+        "operationId": "updateWorker",
+        "parameters": [
+          {
+            "name": "worker_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Worker Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkerUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkerResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Workers"
+        ],
+        "summary": "Delete Worker",
+        "operationId": "deleteWorker",
+        "parameters": [
+          {
+            "name": "worker_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Worker Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/clients/": {
+      "get": {
+        "tags": [
+          "Clients"
+        ],
+        "summary": "Get Clients",
+        "operationId": "getClients",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ClientResponse"
+                  },
+                  "type": "array",
+                  "title": "Response Getclients"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Clients"
+        ],
+        "summary": "Create Client",
+        "operationId": "createClient",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ClientCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/projects/": {
+      "get": {
+        "tags": [
+          "Projects"
+        ],
+        "summary": "Get Projects",
+        "operationId": "getProjects",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ProjectResponse"
+                  },
+                  "type": "array",
+                  "title": "Response Getprojects"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Projects"
+        ],
+        "summary": "Create Project",
+        "operationId": "createProject",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProjectCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ClientCreate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "score": {
+            "type": "integer",
+            "title": "Score"
+          },
+          "create_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Create At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "score"
+        ],
+        "title": "ClientCreate"
+      },
+      "ClientResponse": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "score": {
+            "type": "integer",
+            "title": "Score"
+          },
+          "create_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Create At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          },
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "score",
+          "id"
+        ],
+        "title": "ClientResponse"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "ProjectCreate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "client_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Id"
+          },
+          "worker_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Worker Id"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "ProjectCreate"
+      },
+      "ProjectResponse": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "client_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Id"
+          },
+          "worker_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Worker Id"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          },
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "id"
+        ],
+        "title": "ProjectResponse"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      },
+      "WorkerCreate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "parental_surname": {
+            "type": "string",
+            "title": "Parental Surname"
+          },
+          "maternal_surname": {
+            "type": "string",
+            "title": "Maternal Surname"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "parental_surname",
+          "maternal_surname"
+        ],
+        "title": "WorkerCreate"
+      },
+      "WorkerResponse": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "parental_surname": {
+            "type": "string",
+            "title": "Parental Surname"
+          },
+          "maternal_surname": {
+            "type": "string",
+            "title": "Maternal Surname"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          },
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "parental_surname",
+          "maternal_surname",
+          "id"
+        ],
+        "title": "WorkerResponse"
+      },
+      "WorkerUpdate": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "parental_surname": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parental Surname"
+          },
+          "maternal_surname": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Maternal Surname"
+          }
+        },
+        "type": "object",
+        "title": "WorkerUpdate"
+      }
+    }
+  }
+}

--- a/frontend-app/src/api/fastAPI.schemas.ts
+++ b/frontend-app/src/api/fastAPI.schemas.ts
@@ -23,6 +23,31 @@ export interface HTTPValidationError {
   detail?: ValidationError[];
 }
 
+export type ProjectCreateClientId = number | null;
+
+export type ProjectCreateWorkerId = number | null;
+
+export interface ProjectCreate {
+  name: string;
+  client_id?: ProjectCreateClientId;
+  worker_id?: ProjectCreateWorkerId;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export type ProjectResponseClientId = number | null;
+
+export type ProjectResponseWorkerId = number | null;
+
+export interface ProjectResponse {
+  name: string;
+  client_id?: ProjectResponseClientId;
+  worker_id?: ProjectResponseWorkerId;
+  created_at?: string;
+  updated_at?: string;
+  id: number;
+}
+
 export type ValidationErrorLocItem = string | number;
 
 export interface ValidationError {
@@ -58,32 +83,4 @@ export interface WorkerUpdate {
   name?: WorkerUpdateName;
   parental_surname?: WorkerUpdateParentalSurname;
   maternal_surname?: WorkerUpdateMaternalSurname;
-}
-
-
-export interface ProjectCreate {
-  name: string;
-  client: string;
-  responsible: string;
-  created_at?: string;
-  updated_at?: string;
-}
-
-export interface ProjectResponse {
-  name: string;
-  client: string;
-  responsible: string;
-  created_at?: string;
-  updated_at?: string;
-  id: number;
-}
-
-export type ProjectUpdateName = string | null;
-export type ProjectUpdateClient = string | null;
-export type ProjectUpdateResponsible = string | null;
-
-export interface ProjectUpdate {
-  name?: ProjectUpdateName;
-  client?: ProjectUpdateClient;
-  responsible?: ProjectUpdateResponsible;
 }

--- a/frontend-app/src/api/fastAPI.ts
+++ b/frontend-app/src/api/fastAPI.ts
@@ -4,10 +4,7 @@
  * FastAPI
  * OpenAPI spec version: 0.1.0
  */
-import {
-  useMutation,
-  useQuery
-} from '@tanstack/react-query';
+import { useMutation, useQuery } from "@tanstack/react-query";
 import type {
   DataTag,
   DefinedInitialDataOptions,
@@ -20,713 +17,1047 @@ import type {
   UseMutationOptions,
   UseMutationResult,
   UseQueryOptions,
-  UseQueryResult
-} from '@tanstack/react-query';
+  UseQueryResult,
+} from "@tanstack/react-query";
 
-import * as axios from 'axios';
-import type {
-  AxiosError,
-  AxiosRequestConfig,
-  AxiosResponse
-} from 'axios';
+import * as axios from "axios";
+import type { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
 
 import type {
   ClientCreate,
   ClientResponse,
   HTTPValidationError,
+  ProjectCreate,
+  ProjectResponse,
   WorkerCreate,
   WorkerResponse,
   WorkerUpdate,
-  ProjectCreate,
-  ProjectResponse,
-  ProjectUpdate
-} from './fastAPI.schemas';
-
-
-
-
+} from "./fastAPI.schemas";
 
 /**
  * @summary Create Db And Tables
  */
 export const createDbAndTablesApiDevCreateDbAndTablesPost = (
-     options?: AxiosRequestConfig
- ): Promise<AxiosResponse<unknown>> => {
-    
-    
-    return axios.default.post(
-      `/api/dev/create-db-and-tables`,undefined,options
-    );
-  }
+  options?: AxiosRequestConfig,
+): Promise<AxiosResponse<unknown>> => {
+  return axios.default.post(
+    `/api/dev/create-db-and-tables`,
+    undefined,
+    options,
+  );
+};
 
+export const getCreateDbAndTablesApiDevCreateDbAndTablesPostMutationOptions = <
+  TError = AxiosError<unknown>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof createDbAndTablesApiDevCreateDbAndTablesPost>>,
+    TError,
+    void,
+    TContext
+  >;
+  axios?: AxiosRequestConfig;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof createDbAndTablesApiDevCreateDbAndTablesPost>>,
+  TError,
+  void,
+  TContext
+> => {
+  const mutationKey = ["createDbAndTablesApiDevCreateDbAndTablesPost"];
+  const { mutation: mutationOptions, axios: axiosOptions } = options
+    ? options.mutation &&
+      "mutationKey" in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, axios: undefined };
 
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof createDbAndTablesApiDevCreateDbAndTablesPost>>,
+    void
+  > = () => {
+    return createDbAndTablesApiDevCreateDbAndTablesPost(axiosOptions);
+  };
 
-export const getCreateDbAndTablesApiDevCreateDbAndTablesPostMutationOptions = <TError = AxiosError<unknown>,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof createDbAndTablesApiDevCreateDbAndTablesPost>>, TError,void, TContext>, axios?: AxiosRequestConfig}
-): UseMutationOptions<Awaited<ReturnType<typeof createDbAndTablesApiDevCreateDbAndTablesPost>>, TError,void, TContext> => {
+  return { mutationFn, ...mutationOptions };
+};
 
-const mutationKey = ['createDbAndTablesApiDevCreateDbAndTablesPost'];
-const {mutation: mutationOptions, axios: axiosOptions} = options ?
-      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
-      options
-      : {...options, mutation: {...options.mutation, mutationKey}}
-      : {mutation: { mutationKey, }, axios: undefined};
+export type CreateDbAndTablesApiDevCreateDbAndTablesPostMutationResult =
+  NonNullable<
+    Awaited<ReturnType<typeof createDbAndTablesApiDevCreateDbAndTablesPost>>
+  >;
 
-      
+export type CreateDbAndTablesApiDevCreateDbAndTablesPostMutationError =
+  AxiosError<unknown>;
 
-
-      const mutationFn: MutationFunction<Awaited<ReturnType<typeof createDbAndTablesApiDevCreateDbAndTablesPost>>, void> = () => {
-          
-
-          return  createDbAndTablesApiDevCreateDbAndTablesPost(axiosOptions)
-        }
-
-        
-
-
-  return  { mutationFn, ...mutationOptions }}
-
-    export type CreateDbAndTablesApiDevCreateDbAndTablesPostMutationResult = NonNullable<Awaited<ReturnType<typeof createDbAndTablesApiDevCreateDbAndTablesPost>>>
-    
-    export type CreateDbAndTablesApiDevCreateDbAndTablesPostMutationError = AxiosError<unknown>
-
-    /**
+/**
  * @summary Create Db And Tables
  */
-export const useCreateDbAndTablesApiDevCreateDbAndTablesPost = <TError = AxiosError<unknown>,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof createDbAndTablesApiDevCreateDbAndTablesPost>>, TError,void, TContext>, axios?: AxiosRequestConfig}
- , queryClient?: QueryClient): UseMutationResult<
-        Awaited<ReturnType<typeof createDbAndTablesApiDevCreateDbAndTablesPost>>,
-        TError,
-        void,
-        TContext
-      > => {
+export const useCreateDbAndTablesApiDevCreateDbAndTablesPost = <
+  TError = AxiosError<unknown>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof createDbAndTablesApiDevCreateDbAndTablesPost>>,
+      TError,
+      void,
+      TContext
+    >;
+    axios?: AxiosRequestConfig;
+  },
+  queryClient?: QueryClient,
+): UseMutationResult<
+  Awaited<ReturnType<typeof createDbAndTablesApiDevCreateDbAndTablesPost>>,
+  TError,
+  void,
+  TContext
+> => {
+  const mutationOptions =
+    getCreateDbAndTablesApiDevCreateDbAndTablesPostMutationOptions(options);
 
-      const mutationOptions = getCreateDbAndTablesApiDevCreateDbAndTablesPostMutationOptions(options);
+  return useMutation(mutationOptions, queryClient);
+};
 
-      return useMutation(mutationOptions , queryClient);
-    }
-    
 /**
  * @summary Get Workers
  */
 export const getWorkers = (
-     options?: AxiosRequestConfig
- ): Promise<AxiosResponse<WorkerResponse[]>> => {
-    
-    
-    return axios.default.get(
-      `/api/workers/`,options
-    );
-  }
-
+  options?: AxiosRequestConfig,
+): Promise<AxiosResponse<WorkerResponse[]>> => {
+  return axios.default.get(`/api/workers/`, options);
+};
 
 export const getGetWorkersQueryKey = () => {
-    return [`/api/workers/`] as const;
-    }
+  return [`/api/workers/`] as const;
+};
 
-    
-export const getGetWorkersQueryOptions = <TData = Awaited<ReturnType<typeof getWorkers>>, TError = AxiosError<unknown>>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getWorkers>>, TError, TData>>, axios?: AxiosRequestConfig}
-) => {
+export const getGetWorkersQueryOptions = <
+  TData = Awaited<ReturnType<typeof getWorkers>>,
+  TError = AxiosError<unknown>,
+>(options?: {
+  query?: Partial<
+    UseQueryOptions<Awaited<ReturnType<typeof getWorkers>>, TError, TData>
+  >;
+  axios?: AxiosRequestConfig;
+}) => {
+  const { query: queryOptions, axios: axiosOptions } = options ?? {};
 
-const {query: queryOptions, axios: axiosOptions} = options ?? {};
+  const queryKey = queryOptions?.queryKey ?? getGetWorkersQueryKey();
 
-  const queryKey =  queryOptions?.queryKey ?? getGetWorkersQueryKey();
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof getWorkers>>> = ({
+    signal,
+  }) => getWorkers({ signal, ...axiosOptions });
 
-  
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof getWorkers>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
 
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof getWorkers>>> = ({ signal }) => getWorkers({ signal, ...axiosOptions });
+export type GetWorkersQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getWorkers>>
+>;
+export type GetWorkersQueryError = AxiosError<unknown>;
 
-      
-
-      
-
-   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof getWorkers>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
-}
-
-export type GetWorkersQueryResult = NonNullable<Awaited<ReturnType<typeof getWorkers>>>
-export type GetWorkersQueryError = AxiosError<unknown>
-
-
-export function useGetWorkers<TData = Awaited<ReturnType<typeof getWorkers>>, TError = AxiosError<unknown>>(
-  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof getWorkers>>, TError, TData>> & Pick<
+export function useGetWorkers<
+  TData = Awaited<ReturnType<typeof getWorkers>>,
+  TError = AxiosError<unknown>,
+>(
+  options: {
+    query: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getWorkers>>, TError, TData>
+    > &
+      Pick<
         DefinedInitialDataOptions<
           Awaited<ReturnType<typeof getWorkers>>,
           TError,
           Awaited<ReturnType<typeof getWorkers>>
-        > , 'initialData'
-      >, axios?: AxiosRequestConfig}
- , queryClient?: QueryClient
-  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useGetWorkers<TData = Awaited<ReturnType<typeof getWorkers>>, TError = AxiosError<unknown>>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getWorkers>>, TError, TData>> & Pick<
+        >,
+        "initialData"
+      >;
+    axios?: AxiosRequestConfig;
+  },
+  queryClient?: QueryClient,
+): DefinedUseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetWorkers<
+  TData = Awaited<ReturnType<typeof getWorkers>>,
+  TError = AxiosError<unknown>,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getWorkers>>, TError, TData>
+    > &
+      Pick<
         UndefinedInitialDataOptions<
           Awaited<ReturnType<typeof getWorkers>>,
           TError,
           Awaited<ReturnType<typeof getWorkers>>
-        > , 'initialData'
-      >, axios?: AxiosRequestConfig}
- , queryClient?: QueryClient
-  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useGetWorkers<TData = Awaited<ReturnType<typeof getWorkers>>, TError = AxiosError<unknown>>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getWorkers>>, TError, TData>>, axios?: AxiosRequestConfig}
- , queryClient?: QueryClient
-  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+        >,
+        "initialData"
+      >;
+    axios?: AxiosRequestConfig;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetWorkers<
+  TData = Awaited<ReturnType<typeof getWorkers>>,
+  TError = AxiosError<unknown>,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getWorkers>>, TError, TData>
+    >;
+    axios?: AxiosRequestConfig;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
 /**
  * @summary Get Workers
  */
 
-export function useGetWorkers<TData = Awaited<ReturnType<typeof getWorkers>>, TError = AxiosError<unknown>>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getWorkers>>, TError, TData>>, axios?: AxiosRequestConfig}
- , queryClient?: QueryClient 
- ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+export function useGetWorkers<
+  TData = Awaited<ReturnType<typeof getWorkers>>,
+  TError = AxiosError<unknown>,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getWorkers>>, TError, TData>
+    >;
+    axios?: AxiosRequestConfig;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getGetWorkersQueryOptions(options);
 
-  const queryOptions = getGetWorkersQueryOptions(options)
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
 
-  const query = useQuery(queryOptions , queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-
-  query.queryKey = queryOptions.queryKey ;
+  query.queryKey = queryOptions.queryKey;
 
   return query;
 }
-
-
-
 
 /**
  * @summary Create Worker
  */
 export const createWorker = (
-    workerCreate: WorkerCreate, options?: AxiosRequestConfig
- ): Promise<AxiosResponse<WorkerResponse>> => {
-    
-    
-    return axios.default.post(
-      `/api/workers/`,
-      workerCreate,options
-    );
-  }
+  workerCreate: WorkerCreate,
+  options?: AxiosRequestConfig,
+): Promise<AxiosResponse<WorkerResponse>> => {
+  return axios.default.post(`/api/workers/`, workerCreate, options);
+};
 
+export const getCreateWorkerMutationOptions = <
+  TError = AxiosError<HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof createWorker>>,
+    TError,
+    { data: WorkerCreate },
+    TContext
+  >;
+  axios?: AxiosRequestConfig;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof createWorker>>,
+  TError,
+  { data: WorkerCreate },
+  TContext
+> => {
+  const mutationKey = ["createWorker"];
+  const { mutation: mutationOptions, axios: axiosOptions } = options
+    ? options.mutation &&
+      "mutationKey" in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, axios: undefined };
 
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof createWorker>>,
+    { data: WorkerCreate }
+  > = (props) => {
+    const { data } = props ?? {};
 
-export const getCreateWorkerMutationOptions = <TError = AxiosError<HTTPValidationError>,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof createWorker>>, TError,{data: WorkerCreate}, TContext>, axios?: AxiosRequestConfig}
-): UseMutationOptions<Awaited<ReturnType<typeof createWorker>>, TError,{data: WorkerCreate}, TContext> => {
+    return createWorker(data, axiosOptions);
+  };
 
-const mutationKey = ['createWorker'];
-const {mutation: mutationOptions, axios: axiosOptions} = options ?
-      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
-      options
-      : {...options, mutation: {...options.mutation, mutationKey}}
-      : {mutation: { mutationKey, }, axios: undefined};
+  return { mutationFn, ...mutationOptions };
+};
 
-      
+export type CreateWorkerMutationResult = NonNullable<
+  Awaited<ReturnType<typeof createWorker>>
+>;
+export type CreateWorkerMutationBody = WorkerCreate;
+export type CreateWorkerMutationError = AxiosError<HTTPValidationError>;
 
-
-      const mutationFn: MutationFunction<Awaited<ReturnType<typeof createWorker>>, {data: WorkerCreate}> = (props) => {
-          const {data} = props ?? {};
-
-          return  createWorker(data,axiosOptions)
-        }
-
-        
-
-
-  return  { mutationFn, ...mutationOptions }}
-
-    export type CreateWorkerMutationResult = NonNullable<Awaited<ReturnType<typeof createWorker>>>
-    export type CreateWorkerMutationBody = WorkerCreate
-    export type CreateWorkerMutationError = AxiosError<HTTPValidationError>
-
-    /**
+/**
  * @summary Create Worker
  */
-export const useCreateWorker = <TError = AxiosError<HTTPValidationError>,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof createWorker>>, TError,{data: WorkerCreate}, TContext>, axios?: AxiosRequestConfig}
- , queryClient?: QueryClient): UseMutationResult<
-        Awaited<ReturnType<typeof createWorker>>,
-        TError,
-        {data: WorkerCreate},
-        TContext
-      > => {
+export const useCreateWorker = <
+  TError = AxiosError<HTTPValidationError>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof createWorker>>,
+      TError,
+      { data: WorkerCreate },
+      TContext
+    >;
+    axios?: AxiosRequestConfig;
+  },
+  queryClient?: QueryClient,
+): UseMutationResult<
+  Awaited<ReturnType<typeof createWorker>>,
+  TError,
+  { data: WorkerCreate },
+  TContext
+> => {
+  const mutationOptions = getCreateWorkerMutationOptions(options);
 
-      const mutationOptions = getCreateWorkerMutationOptions(options);
+  return useMutation(mutationOptions, queryClient);
+};
 
-      return useMutation(mutationOptions , queryClient);
-    }
-    
 /**
  * @summary Get Worker
  */
 export const getWorker = (
-    workerId: number, options?: AxiosRequestConfig
- ): Promise<AxiosResponse<WorkerResponse>> => {
-    
-    
-    return axios.default.get(
-      `/api/workers/${workerId}`,options
-    );
-  }
+  workerId: number,
+  options?: AxiosRequestConfig,
+): Promise<AxiosResponse<WorkerResponse>> => {
+  return axios.default.get(`/api/workers/${workerId}`, options);
+};
 
+export const getGetWorkerQueryKey = (workerId: number) => {
+  return [`/api/workers/${workerId}`] as const;
+};
 
-export const getGetWorkerQueryKey = (workerId: number,) => {
-    return [`/api/workers/${workerId}`] as const;
-    }
-
-    
-export const getGetWorkerQueryOptions = <TData = Awaited<ReturnType<typeof getWorker>>, TError = AxiosError<HTTPValidationError>>(workerId: number, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getWorker>>, TError, TData>>, axios?: AxiosRequestConfig}
+export const getGetWorkerQueryOptions = <
+  TData = Awaited<ReturnType<typeof getWorker>>,
+  TError = AxiosError<HTTPValidationError>,
+>(
+  workerId: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getWorker>>, TError, TData>
+    >;
+    axios?: AxiosRequestConfig;
+  },
 ) => {
+  const { query: queryOptions, axios: axiosOptions } = options ?? {};
 
-const {query: queryOptions, axios: axiosOptions} = options ?? {};
+  const queryKey = queryOptions?.queryKey ?? getGetWorkerQueryKey(workerId);
 
-  const queryKey =  queryOptions?.queryKey ?? getGetWorkerQueryKey(workerId);
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof getWorker>>> = ({
+    signal,
+  }) => getWorker(workerId, { signal, ...axiosOptions });
 
-  
+  return {
+    queryKey,
+    queryFn,
+    enabled: !!workerId,
+    ...queryOptions,
+  } as UseQueryOptions<Awaited<ReturnType<typeof getWorker>>, TError, TData> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+  };
+};
 
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof getWorker>>> = ({ signal }) => getWorker(workerId, { signal, ...axiosOptions });
+export type GetWorkerQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getWorker>>
+>;
+export type GetWorkerQueryError = AxiosError<HTTPValidationError>;
 
-      
-
-      
-
-   return  { queryKey, queryFn, enabled: !!(workerId), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof getWorker>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
-}
-
-export type GetWorkerQueryResult = NonNullable<Awaited<ReturnType<typeof getWorker>>>
-export type GetWorkerQueryError = AxiosError<HTTPValidationError>
-
-
-export function useGetWorker<TData = Awaited<ReturnType<typeof getWorker>>, TError = AxiosError<HTTPValidationError>>(
- workerId: number, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof getWorker>>, TError, TData>> & Pick<
+export function useGetWorker<
+  TData = Awaited<ReturnType<typeof getWorker>>,
+  TError = AxiosError<HTTPValidationError>,
+>(
+  workerId: number,
+  options: {
+    query: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getWorker>>, TError, TData>
+    > &
+      Pick<
         DefinedInitialDataOptions<
           Awaited<ReturnType<typeof getWorker>>,
           TError,
           Awaited<ReturnType<typeof getWorker>>
-        > , 'initialData'
-      >, axios?: AxiosRequestConfig}
- , queryClient?: QueryClient
-  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useGetWorker<TData = Awaited<ReturnType<typeof getWorker>>, TError = AxiosError<HTTPValidationError>>(
- workerId: number, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getWorker>>, TError, TData>> & Pick<
+        >,
+        "initialData"
+      >;
+    axios?: AxiosRequestConfig;
+  },
+  queryClient?: QueryClient,
+): DefinedUseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetWorker<
+  TData = Awaited<ReturnType<typeof getWorker>>,
+  TError = AxiosError<HTTPValidationError>,
+>(
+  workerId: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getWorker>>, TError, TData>
+    > &
+      Pick<
         UndefinedInitialDataOptions<
           Awaited<ReturnType<typeof getWorker>>,
           TError,
           Awaited<ReturnType<typeof getWorker>>
-        > , 'initialData'
-      >, axios?: AxiosRequestConfig}
- , queryClient?: QueryClient
-  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useGetWorker<TData = Awaited<ReturnType<typeof getWorker>>, TError = AxiosError<HTTPValidationError>>(
- workerId: number, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getWorker>>, TError, TData>>, axios?: AxiosRequestConfig}
- , queryClient?: QueryClient
-  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+        >,
+        "initialData"
+      >;
+    axios?: AxiosRequestConfig;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetWorker<
+  TData = Awaited<ReturnType<typeof getWorker>>,
+  TError = AxiosError<HTTPValidationError>,
+>(
+  workerId: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getWorker>>, TError, TData>
+    >;
+    axios?: AxiosRequestConfig;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
 /**
  * @summary Get Worker
  */
 
-export function useGetWorker<TData = Awaited<ReturnType<typeof getWorker>>, TError = AxiosError<HTTPValidationError>>(
- workerId: number, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getWorker>>, TError, TData>>, axios?: AxiosRequestConfig}
- , queryClient?: QueryClient 
- ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+export function useGetWorker<
+  TData = Awaited<ReturnType<typeof getWorker>>,
+  TError = AxiosError<HTTPValidationError>,
+>(
+  workerId: number,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getWorker>>, TError, TData>
+    >;
+    axios?: AxiosRequestConfig;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getGetWorkerQueryOptions(workerId, options);
 
-  const queryOptions = getGetWorkerQueryOptions(workerId,options)
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
 
-  const query = useQuery(queryOptions , queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-
-  query.queryKey = queryOptions.queryKey ;
+  query.queryKey = queryOptions.queryKey;
 
   return query;
 }
-
-
-
 
 /**
  * @summary Update Worker
  */
 export const updateWorker = (
-    workerId: number,
-    workerUpdate: WorkerUpdate, options?: AxiosRequestConfig
- ): Promise<AxiosResponse<WorkerResponse>> => {
-    
-    
-    return axios.default.put(
-      `/api/workers/${workerId}`,
-      workerUpdate,options
-    );
-  }
+  workerId: number,
+  workerUpdate: WorkerUpdate,
+  options?: AxiosRequestConfig,
+): Promise<AxiosResponse<WorkerResponse>> => {
+  return axios.default.put(`/api/workers/${workerId}`, workerUpdate, options);
+};
 
+export const getUpdateWorkerMutationOptions = <
+  TError = AxiosError<HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof updateWorker>>,
+    TError,
+    { workerId: number; data: WorkerUpdate },
+    TContext
+  >;
+  axios?: AxiosRequestConfig;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof updateWorker>>,
+  TError,
+  { workerId: number; data: WorkerUpdate },
+  TContext
+> => {
+  const mutationKey = ["updateWorker"];
+  const { mutation: mutationOptions, axios: axiosOptions } = options
+    ? options.mutation &&
+      "mutationKey" in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, axios: undefined };
 
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof updateWorker>>,
+    { workerId: number; data: WorkerUpdate }
+  > = (props) => {
+    const { workerId, data } = props ?? {};
 
-export const getUpdateWorkerMutationOptions = <TError = AxiosError<HTTPValidationError>,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof updateWorker>>, TError,{workerId: number;data: WorkerUpdate}, TContext>, axios?: AxiosRequestConfig}
-): UseMutationOptions<Awaited<ReturnType<typeof updateWorker>>, TError,{workerId: number;data: WorkerUpdate}, TContext> => {
+    return updateWorker(workerId, data, axiosOptions);
+  };
 
-const mutationKey = ['updateWorker'];
-const {mutation: mutationOptions, axios: axiosOptions} = options ?
-      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
-      options
-      : {...options, mutation: {...options.mutation, mutationKey}}
-      : {mutation: { mutationKey, }, axios: undefined};
+  return { mutationFn, ...mutationOptions };
+};
 
-      
+export type UpdateWorkerMutationResult = NonNullable<
+  Awaited<ReturnType<typeof updateWorker>>
+>;
+export type UpdateWorkerMutationBody = WorkerUpdate;
+export type UpdateWorkerMutationError = AxiosError<HTTPValidationError>;
 
-
-      const mutationFn: MutationFunction<Awaited<ReturnType<typeof updateWorker>>, {workerId: number;data: WorkerUpdate}> = (props) => {
-          const {workerId,data} = props ?? {};
-
-          return  updateWorker(workerId,data,axiosOptions)
-        }
-
-        
-
-
-  return  { mutationFn, ...mutationOptions }}
-
-    export type UpdateWorkerMutationResult = NonNullable<Awaited<ReturnType<typeof updateWorker>>>
-    export type UpdateWorkerMutationBody = WorkerUpdate
-    export type UpdateWorkerMutationError = AxiosError<HTTPValidationError>
-
-    /**
+/**
  * @summary Update Worker
  */
-export const useUpdateWorker = <TError = AxiosError<HTTPValidationError>,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof updateWorker>>, TError,{workerId: number;data: WorkerUpdate}, TContext>, axios?: AxiosRequestConfig}
- , queryClient?: QueryClient): UseMutationResult<
-        Awaited<ReturnType<typeof updateWorker>>,
-        TError,
-        {workerId: number;data: WorkerUpdate},
-        TContext
-      > => {
+export const useUpdateWorker = <
+  TError = AxiosError<HTTPValidationError>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof updateWorker>>,
+      TError,
+      { workerId: number; data: WorkerUpdate },
+      TContext
+    >;
+    axios?: AxiosRequestConfig;
+  },
+  queryClient?: QueryClient,
+): UseMutationResult<
+  Awaited<ReturnType<typeof updateWorker>>,
+  TError,
+  { workerId: number; data: WorkerUpdate },
+  TContext
+> => {
+  const mutationOptions = getUpdateWorkerMutationOptions(options);
 
-      const mutationOptions = getUpdateWorkerMutationOptions(options);
+  return useMutation(mutationOptions, queryClient);
+};
 
-      return useMutation(mutationOptions , queryClient);
-    }
-    
 /**
  * @summary Delete Worker
  */
 export const deleteWorker = (
-    workerId: number, options?: AxiosRequestConfig
- ): Promise<AxiosResponse<void>> => {
-    
-    
-    return axios.default.delete(
-      `/api/workers/${workerId}`,options
-    );
-  }
+  workerId: number,
+  options?: AxiosRequestConfig,
+): Promise<AxiosResponse<void>> => {
+  return axios.default.delete(`/api/workers/${workerId}`, options);
+};
 
+export const getDeleteWorkerMutationOptions = <
+  TError = AxiosError<HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof deleteWorker>>,
+    TError,
+    { workerId: number },
+    TContext
+  >;
+  axios?: AxiosRequestConfig;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof deleteWorker>>,
+  TError,
+  { workerId: number },
+  TContext
+> => {
+  const mutationKey = ["deleteWorker"];
+  const { mutation: mutationOptions, axios: axiosOptions } = options
+    ? options.mutation &&
+      "mutationKey" in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, axios: undefined };
 
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof deleteWorker>>,
+    { workerId: number }
+  > = (props) => {
+    const { workerId } = props ?? {};
 
-export const getDeleteWorkerMutationOptions = <TError = AxiosError<HTTPValidationError>,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof deleteWorker>>, TError,{workerId: number}, TContext>, axios?: AxiosRequestConfig}
-): UseMutationOptions<Awaited<ReturnType<typeof deleteWorker>>, TError,{workerId: number}, TContext> => {
+    return deleteWorker(workerId, axiosOptions);
+  };
 
-const mutationKey = ['deleteWorker'];
-const {mutation: mutationOptions, axios: axiosOptions} = options ?
-      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
-      options
-      : {...options, mutation: {...options.mutation, mutationKey}}
-      : {mutation: { mutationKey, }, axios: undefined};
+  return { mutationFn, ...mutationOptions };
+};
 
-      
+export type DeleteWorkerMutationResult = NonNullable<
+  Awaited<ReturnType<typeof deleteWorker>>
+>;
 
+export type DeleteWorkerMutationError = AxiosError<HTTPValidationError>;
 
-      const mutationFn: MutationFunction<Awaited<ReturnType<typeof deleteWorker>>, {workerId: number}> = (props) => {
-          const {workerId} = props ?? {};
-
-          return  deleteWorker(workerId,axiosOptions)
-        }
-
-        
-
-
-  return  { mutationFn, ...mutationOptions }}
-
-    export type DeleteWorkerMutationResult = NonNullable<Awaited<ReturnType<typeof deleteWorker>>>
-    
-    export type DeleteWorkerMutationError = AxiosError<HTTPValidationError>
-
-    /**
+/**
  * @summary Delete Worker
  */
-export const useDeleteWorker = <TError = AxiosError<HTTPValidationError>,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof deleteWorker>>, TError,{workerId: number}, TContext>, axios?: AxiosRequestConfig}
- , queryClient?: QueryClient): UseMutationResult<
-        Awaited<ReturnType<typeof deleteWorker>>,
-        TError,
-        {workerId: number},
-        TContext
-      > => {
+export const useDeleteWorker = <
+  TError = AxiosError<HTTPValidationError>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof deleteWorker>>,
+      TError,
+      { workerId: number },
+      TContext
+    >;
+    axios?: AxiosRequestConfig;
+  },
+  queryClient?: QueryClient,
+): UseMutationResult<
+  Awaited<ReturnType<typeof deleteWorker>>,
+  TError,
+  { workerId: number },
+  TContext
+> => {
+  const mutationOptions = getDeleteWorkerMutationOptions(options);
 
-      const mutationOptions = getDeleteWorkerMutationOptions(options);
+  return useMutation(mutationOptions, queryClient);
+};
 
-      return useMutation(mutationOptions , queryClient);
-    }
-    
 /**
  * @summary Get Clients
  */
 export const getClients = (
-     options?: AxiosRequestConfig
- ): Promise<AxiosResponse<ClientResponse[]>> => {
-    
-    
-    return axios.default.get(
-      `/api/clients/`,options
-    );
-  }
-
+  options?: AxiosRequestConfig,
+): Promise<AxiosResponse<ClientResponse[]>> => {
+  return axios.default.get(`/api/clients/`, options);
+};
 
 export const getGetClientsQueryKey = () => {
-    return [`/api/clients/`] as const;
-    }
+  return [`/api/clients/`] as const;
+};
 
-    
-export const getGetClientsQueryOptions = <TData = Awaited<ReturnType<typeof getClients>>, TError = AxiosError<unknown>>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getClients>>, TError, TData>>, axios?: AxiosRequestConfig}
-) => {
+export const getGetClientsQueryOptions = <
+  TData = Awaited<ReturnType<typeof getClients>>,
+  TError = AxiosError<unknown>,
+>(options?: {
+  query?: Partial<
+    UseQueryOptions<Awaited<ReturnType<typeof getClients>>, TError, TData>
+  >;
+  axios?: AxiosRequestConfig;
+}) => {
+  const { query: queryOptions, axios: axiosOptions } = options ?? {};
 
-const {query: queryOptions, axios: axiosOptions} = options ?? {};
+  const queryKey = queryOptions?.queryKey ?? getGetClientsQueryKey();
 
-  const queryKey =  queryOptions?.queryKey ?? getGetClientsQueryKey();
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof getClients>>> = ({
+    signal,
+  }) => getClients({ signal, ...axiosOptions });
 
-  
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof getClients>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
 
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof getClients>>> = ({ signal }) => getClients({ signal, ...axiosOptions });
+export type GetClientsQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getClients>>
+>;
+export type GetClientsQueryError = AxiosError<unknown>;
 
-      
-
-      
-
-   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof getClients>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
-}
-
-export type GetClientsQueryResult = NonNullable<Awaited<ReturnType<typeof getClients>>>
-export type GetClientsQueryError = AxiosError<unknown>
-
-
-export function useGetClients<TData = Awaited<ReturnType<typeof getClients>>, TError = AxiosError<unknown>>(
-  options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof getClients>>, TError, TData>> & Pick<
+export function useGetClients<
+  TData = Awaited<ReturnType<typeof getClients>>,
+  TError = AxiosError<unknown>,
+>(
+  options: {
+    query: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getClients>>, TError, TData>
+    > &
+      Pick<
         DefinedInitialDataOptions<
           Awaited<ReturnType<typeof getClients>>,
           TError,
           Awaited<ReturnType<typeof getClients>>
-        > , 'initialData'
-      >, axios?: AxiosRequestConfig}
- , queryClient?: QueryClient
-  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useGetClients<TData = Awaited<ReturnType<typeof getClients>>, TError = AxiosError<unknown>>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getClients>>, TError, TData>> & Pick<
+        >,
+        "initialData"
+      >;
+    axios?: AxiosRequestConfig;
+  },
+  queryClient?: QueryClient,
+): DefinedUseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetClients<
+  TData = Awaited<ReturnType<typeof getClients>>,
+  TError = AxiosError<unknown>,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getClients>>, TError, TData>
+    > &
+      Pick<
         UndefinedInitialDataOptions<
           Awaited<ReturnType<typeof getClients>>,
           TError,
           Awaited<ReturnType<typeof getClients>>
-        > , 'initialData'
-      >, axios?: AxiosRequestConfig}
- , queryClient?: QueryClient
-  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
-export function useGetClients<TData = Awaited<ReturnType<typeof getClients>>, TError = AxiosError<unknown>>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getClients>>, TError, TData>>, axios?: AxiosRequestConfig}
- , queryClient?: QueryClient
-  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
+        >,
+        "initialData"
+      >;
+    axios?: AxiosRequestConfig;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetClients<
+  TData = Awaited<ReturnType<typeof getClients>>,
+  TError = AxiosError<unknown>,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getClients>>, TError, TData>
+    >;
+    axios?: AxiosRequestConfig;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
 /**
  * @summary Get Clients
  */
 
-export function useGetClients<TData = Awaited<ReturnType<typeof getClients>>, TError = AxiosError<unknown>>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getClients>>, TError, TData>>, axios?: AxiosRequestConfig}
- , queryClient?: QueryClient 
- ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+export function useGetClients<
+  TData = Awaited<ReturnType<typeof getClients>>,
+  TError = AxiosError<unknown>,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getClients>>, TError, TData>
+    >;
+    axios?: AxiosRequestConfig;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getGetClientsQueryOptions(options);
 
-  const queryOptions = getGetClientsQueryOptions(options)
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
 
-  const query = useQuery(queryOptions , queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-
-  query.queryKey = queryOptions.queryKey ;
+  query.queryKey = queryOptions.queryKey;
 
   return query;
 }
-
-
-
 
 /**
  * @summary Create Client
  */
 export const createClient = (
-    clientCreate: ClientCreate, options?: AxiosRequestConfig
- ): Promise<AxiosResponse<ClientResponse>> => {
-    
-    
-    return axios.default.post(
-      `/api/clients/`,
-      clientCreate,options
-    );
-  }
+  clientCreate: ClientCreate,
+  options?: AxiosRequestConfig,
+): Promise<AxiosResponse<ClientResponse>> => {
+  return axios.default.post(`/api/clients/`, clientCreate, options);
+};
 
+export const getCreateClientMutationOptions = <
+  TError = AxiosError<HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof createClient>>,
+    TError,
+    { data: ClientCreate },
+    TContext
+  >;
+  axios?: AxiosRequestConfig;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof createClient>>,
+  TError,
+  { data: ClientCreate },
+  TContext
+> => {
+  const mutationKey = ["createClient"];
+  const { mutation: mutationOptions, axios: axiosOptions } = options
+    ? options.mutation &&
+      "mutationKey" in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, axios: undefined };
 
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof createClient>>,
+    { data: ClientCreate }
+  > = (props) => {
+    const { data } = props ?? {};
 
-export const getCreateClientMutationOptions = <TError = AxiosError<HTTPValidationError>,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof createClient>>, TError,{data: ClientCreate}, TContext>, axios?: AxiosRequestConfig}
-): UseMutationOptions<Awaited<ReturnType<typeof createClient>>, TError,{data: ClientCreate}, TContext> => {
+    return createClient(data, axiosOptions);
+  };
 
-const mutationKey = ['createClient'];
-const {mutation: mutationOptions, axios: axiosOptions} = options ?
-      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
-      options
-      : {...options, mutation: {...options.mutation, mutationKey}}
-      : {mutation: { mutationKey, }, axios: undefined};
+  return { mutationFn, ...mutationOptions };
+};
 
-      
+export type CreateClientMutationResult = NonNullable<
+  Awaited<ReturnType<typeof createClient>>
+>;
+export type CreateClientMutationBody = ClientCreate;
+export type CreateClientMutationError = AxiosError<HTTPValidationError>;
 
-
-      const mutationFn: MutationFunction<Awaited<ReturnType<typeof createClient>>, {data: ClientCreate}> = (props) => {
-          const {data} = props ?? {};
-
-          return  createClient(data,axiosOptions)
-        }
-
-        
-
-
-  return  { mutationFn, ...mutationOptions }}
-
-    export type CreateClientMutationResult = NonNullable<Awaited<ReturnType<typeof createClient>>>
-    export type CreateClientMutationBody = ClientCreate
-    export type CreateClientMutationError = AxiosError<HTTPValidationError>
-
-    /**
+/**
  * @summary Create Client
  */
-export const useCreateClient = <TError = AxiosError<HTTPValidationError>,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof createClient>>, TError,{data: ClientCreate}, TContext>, axios?: AxiosRequestConfig}
- , queryClient?: QueryClient): UseMutationResult<
-        Awaited<ReturnType<typeof createClient>>,
-        TError,
-        {data: ClientCreate},
-        TContext
-      > => {
+export const useCreateClient = <
+  TError = AxiosError<HTTPValidationError>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof createClient>>,
+      TError,
+      { data: ClientCreate },
+      TContext
+    >;
+    axios?: AxiosRequestConfig;
+  },
+  queryClient?: QueryClient,
+): UseMutationResult<
+  Awaited<ReturnType<typeof createClient>>,
+  TError,
+  { data: ClientCreate },
+  TContext
+> => {
+  const mutationOptions = getCreateClientMutationOptions(options);
 
-      const mutationOptions = getCreateClientMutationOptions(options);
-
-      return useMutation(mutationOptions , queryClient);
-    }
+  return useMutation(mutationOptions, queryClient);
+};
 
 /**
  * @summary Get Projects
  */
 export const getProjects = (
-     options?: AxiosRequestConfig
- ): Promise<AxiosResponse<ProjectResponse[]>> => {
-
-
-    return axios.default.get(
-      `/api/projects/`,options
-    );
-  }
-
+  options?: AxiosRequestConfig,
+): Promise<AxiosResponse<ProjectResponse[]>> => {
+  return axios.default.get(`/api/projects/`, options);
+};
 
 export const getGetProjectsQueryKey = () => {
-    return [`/api/projects/`] as const;
-    }
+  return [`/api/projects/`] as const;
+};
 
+export const getGetProjectsQueryOptions = <
+  TData = Awaited<ReturnType<typeof getProjects>>,
+  TError = AxiosError<unknown>,
+>(options?: {
+  query?: Partial<
+    UseQueryOptions<Awaited<ReturnType<typeof getProjects>>, TError, TData>
+  >;
+  axios?: AxiosRequestConfig;
+}) => {
+  const { query: queryOptions, axios: axiosOptions } = options ?? {};
 
-export const getGetProjectsQueryOptions = <TData = Awaited<ReturnType<typeof getProjects>>, TError = AxiosError<unknown>>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getProjects>>, TError, TData>>, axios?: AxiosRequestConfig}
-) => {
+  const queryKey = queryOptions?.queryKey ?? getGetProjectsQueryKey();
 
-const {query: queryOptions, axios: axiosOptions} = options ?? {};
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof getProjects>>> = ({
+    signal,
+  }) => getProjects({ signal, ...axiosOptions });
 
-  const queryKey =  queryOptions?.queryKey ?? getGetProjectsQueryKey();
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof getProjects>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
 
-
-
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof getProjects>>> = ({ signal }) => getProjects({ signal, ...axiosOptions });
-
-
-
-
-   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof getProjects>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
-}
-
-export type GetProjectsQueryResult = NonNullable<Awaited<ReturnType<typeof getProjects>>>;
+export type GetProjectsQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getProjects>>
+>;
 export type GetProjectsQueryError = AxiosError<unknown>;
 
+export function useGetProjects<
+  TData = Awaited<ReturnType<typeof getProjects>>,
+  TError = AxiosError<unknown>,
+>(
+  options: {
+    query: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getProjects>>, TError, TData>
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getProjects>>,
+          TError,
+          Awaited<ReturnType<typeof getProjects>>
+        >,
+        "initialData"
+      >;
+    axios?: AxiosRequestConfig;
+  },
+  queryClient?: QueryClient,
+): DefinedUseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetProjects<
+  TData = Awaited<ReturnType<typeof getProjects>>,
+  TError = AxiosError<unknown>,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getProjects>>, TError, TData>
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getProjects>>,
+          TError,
+          Awaited<ReturnType<typeof getProjects>>
+        >,
+        "initialData"
+      >;
+    axios?: AxiosRequestConfig;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetProjects<
+  TData = Awaited<ReturnType<typeof getProjects>>,
+  TError = AxiosError<unknown>,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getProjects>>, TError, TData>
+    >;
+    axios?: AxiosRequestConfig;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+/**
+ * @summary Get Projects
+ */
 
-export function useGetProjects<TData = Awaited<ReturnType<typeof getProjects>>, TError = AxiosError<unknown>>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getProjects>>, TError, TData>>, axios?: AxiosRequestConfig}
- , queryClient?: QueryClient
- ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
+export function useGetProjects<
+  TData = Awaited<ReturnType<typeof getProjects>>,
+  TError = AxiosError<unknown>,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getProjects>>, TError, TData>
+    >;
+    axios?: AxiosRequestConfig;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getGetProjectsQueryOptions(options);
 
-  const queryOptions = getGetProjectsQueryOptions(options)
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
 
-  const query = useQuery(queryOptions , queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
-
-  query.queryKey = queryOptions.queryKey ;
+  query.queryKey = queryOptions.queryKey;
 
   return query;
 }
-
 
 /**
  * @summary Create Project
  */
 export const createProject = (
-    projectCreate: ProjectCreate, options?: AxiosRequestConfig
- ): Promise<AxiosResponse<ProjectResponse>> => {
+  projectCreate: ProjectCreate,
+  options?: AxiosRequestConfig,
+): Promise<AxiosResponse<ProjectResponse>> => {
+  return axios.default.post(`/api/projects/`, projectCreate, options);
+};
 
+export const getCreateProjectMutationOptions = <
+  TError = AxiosError<HTTPValidationError>,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof createProject>>,
+    TError,
+    { data: ProjectCreate },
+    TContext
+  >;
+  axios?: AxiosRequestConfig;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof createProject>>,
+  TError,
+  { data: ProjectCreate },
+  TContext
+> => {
+  const mutationKey = ["createProject"];
+  const { mutation: mutationOptions, axios: axiosOptions } = options
+    ? options.mutation &&
+      "mutationKey" in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, axios: undefined };
 
-    return axios.default.post(
-      `/api/projects/`,
-      projectCreate,options
-    );
-  }
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof createProject>>,
+    { data: ProjectCreate }
+  > = (props) => {
+    const { data } = props ?? {};
 
+    return createProject(data, axiosOptions);
+  };
 
+  return { mutationFn, ...mutationOptions };
+};
 
-export const getCreateProjectMutationOptions = <TError = AxiosError<HTTPValidationError>,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof createProject>>, TError,{data: ProjectCreate}, TContext>, axios?: AxiosRequestConfig}
-): UseMutationOptions<Awaited<ReturnType<typeof createProject>>, TError,{data: ProjectCreate}, TContext> => {
+export type CreateProjectMutationResult = NonNullable<
+  Awaited<ReturnType<typeof createProject>>
+>;
+export type CreateProjectMutationBody = ProjectCreate;
+export type CreateProjectMutationError = AxiosError<HTTPValidationError>;
 
-const mutationKey = ['createProject'];
-const {mutation: mutationOptions, axios: axiosOptions} = options ?
-      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
-      options
-      : {...options, mutation: {...options.mutation, mutationKey}}
-      : {mutation: { mutationKey, }, axios: undefined};
-
-
-
-
-      const mutationFn: MutationFunction<Awaited<ReturnType<typeof createProject>>, {data: ProjectCreate}> = (props) => {
-          const {data} = props ?? {};
-
-          return  createProject(data,axiosOptions)
-        }
-
-
-
-
-  return  { mutationFn, ...mutationOptions }}
-
-    export type CreateProjectMutationResult = NonNullable<Awaited<ReturnType<typeof createProject>>>;
-    export type CreateProjectMutationBody = ProjectCreate;
-    export type CreateProjectMutationError = AxiosError<HTTPValidationError>;
-
-    /**
+/**
  * @summary Create Project
  */
-export const useCreateProject = <TError = AxiosError<HTTPValidationError>,
-    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof createProject>>, TError,{data: ProjectCreate}, TContext>, axios?: AxiosRequestConfig}
- , queryClient?: QueryClient): UseMutationResult<
-        Awaited<ReturnType<typeof createProject>>,
-        TError,
-        {data: ProjectCreate},
-        TContext
-      > => {
+export const useCreateProject = <
+  TError = AxiosError<HTTPValidationError>,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof createProject>>,
+      TError,
+      { data: ProjectCreate },
+      TContext
+    >;
+    axios?: AxiosRequestConfig;
+  },
+  queryClient?: QueryClient,
+): UseMutationResult<
+  Awaited<ReturnType<typeof createProject>>,
+  TError,
+  { data: ProjectCreate },
+  TContext
+> => {
+  const mutationOptions = getCreateProjectMutationOptions(options);
 
-      const mutationOptions = getCreateProjectMutationOptions(options);
-
-      return useMutation(mutationOptions , queryClient);
-    }
-    
+  return useMutation(mutationOptions, queryClient);
+};

--- a/frontend-app/src/components/ProjectList.tsx
+++ b/frontend-app/src/components/ProjectList.tsx
@@ -1,8 +1,15 @@
 import React, { useState, useRef } from 'react'
-import { useGetProjects, useCreateProject } from '../api/fastAPI'
+import {
+  useGetProjects,
+  useCreateProject,
+  useGetClients,
+  useGetWorkers,
+} from '../api/fastAPI'
 import type { ProjectCreate } from '../api/fastAPI.schemas'
 import {
   IxInput,
+  IxSelect,
+  IxSelectItem,
   IxButton,
   IxModal,
   IxModalHeader,
@@ -13,18 +20,23 @@ import {
 export function ProjectList() {
   const { data, refetch } = useGetProjects()
   const createProject = useCreateProject()
+  const { data: clientsData } = useGetClients()
+  const { data: workersData } = useGetWorkers()
   const modalRef = useRef<HTMLIxModalElement>(null)
   const [form, setForm] = useState<ProjectCreate>({
     name: '',
-    client: '',
-    responsible: '',
+    client_id: undefined,
+    worker_id: undefined,
   })
 
   const handleChange = (field: keyof ProjectCreate) => (
     event: CustomEvent<{ value: string }> | any,
   ) => {
     const value = event.detail?.value ?? event.target.value
-    setForm(prev => ({ ...prev, [field]: value }))
+    setForm(prev => ({
+      ...prev,
+      [field]: field === 'client_id' || field === 'worker_id' ? Number(value) : value,
+    }))
   }
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -33,7 +45,7 @@ export function ProjectList() {
       { data: form },
       {
         onSuccess: () => {
-          setForm({ name: '', client: '', responsible: '' })
+          setForm({ name: '', client_id: undefined, worker_id: undefined })
           modalRef.current?.closeModal()
           refetch()
         },
@@ -57,16 +69,26 @@ export function ProjectList() {
               value={form.name}
               onInput={handleChange('name')}
             />
-            <IxInput
-              placeholder="Cliente"
-              value={form.client}
-              onInput={handleChange('client')}
-            />
-            <IxInput
-              placeholder="Responsable"
-              value={form.responsible}
-              onInput={handleChange('responsible')}
-            />
+            <IxSelect
+              value={form.client_id?.toString() ?? ''}
+              onValueChange={handleChange('client_id')}
+            >
+              {(clientsData?.data ?? []).map(c => (
+                <IxSelectItem key={c.id} label={c.name} value={c.id.toString()} />
+              ))}
+            </IxSelect>
+            <IxSelect
+              value={form.worker_id?.toString() ?? ''}
+              onValueChange={handleChange('worker_id')}
+            >
+              {(workersData?.data ?? []).map(w => (
+                <IxSelectItem
+                  key={w.id}
+                  label={`${w.name} ${w.parental_surname}`}
+                  value={w.id.toString()}
+                />
+              ))}
+            </IxSelect>
           </form>
         </IxModalContent>
         <IxModalFooter>
@@ -90,8 +112,8 @@ export function ProjectList() {
             <tr key={p.id}>
               <td>{p.id}</td>
               <td>{p.name}</td>
-              <td>{p.client}</td>
-              <td>{p.responsible}</td>
+              <td>{p.client_id}</td>
+              <td>{p.worker_id}</td>
             </tr>
           ))}
         </tbody>


### PR DESCRIPTION
## Summary
- link project, client and worker tables in backend models
- regenerate OpenAPI and API client
- update project form to use ix-select for existing clients and workers

## Testing
- `npm run lint` *(fails: no-unused-vars and explicit-any)*
- `npm run build` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_b_6860ed2b56b08320b31cdb2d5bbf37dc