### PR TITLE
Enable worker photo upload

### DIFF
--- a/backend-app/.gitignore
+++ b/backend-app/.gitignore
@@ -8,3 +8,4 @@ wheels/
 
 # Virtual environments
 .venv
+static/

--- a/backend-app/api/workers.py
+++ b/backend-app/api/workers.py
@@ -1,5 +1,7 @@
-from fastapi import APIRouter, HTTPException, Depends, status
+from fastapi import APIRouter, HTTPException, Depends, status, UploadFile, File
 from fastapi.responses import JSONResponse
+import os
+import shutil
 from sqlmodel import Session, select
 from datetime import datetime
 from models.worker import Worker, WorkerCreate, WorkerResponse, WorkerUpdate
@@ -40,6 +42,29 @@ def update_worker(worker_id: int, worker_update: WorkerUpdate, session: Session 
     for key, value in worker_data.items():
         setattr(db_worker, key, value)
     db_worker.updated_at = datetime.utcnow()
+    session.add(db_worker)
+    session.commit()
+    session.refresh(db_worker)
+    return db_worker
+
+
+@router.post("/{worker_id}/photo", response_model=WorkerResponse, operation_id="uploadWorkerPhoto")
+async def upload_worker_photo(
+    worker_id: int,
+    file: UploadFile = File(...),
+    session: Session = Depends(get_session),
+):
+    db_worker = session.get(Worker, worker_id)
+    if not db_worker:
+        raise HTTPException(status_code=404, detail="Worker not found")
+
+    upload_dir = os.path.join(os.path.dirname(__file__), "../static/workers")
+    os.makedirs(upload_dir, exist_ok=True)
+    file_path = os.path.join(upload_dir, f"{worker_id}_{file.filename}")
+    with open(file_path, "wb") as buffer:
+        shutil.copyfileobj(file.file, buffer)
+
+    db_worker.photo_url = f"/static/workers/{worker_id}_{file.filename}"
     session.add(db_worker)
     session.commit()
     session.refresh(db_worker)

--- a/backend-app/main.py
+++ b/backend-app/main.py
@@ -1,8 +1,14 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
 from api import api_router
+import os
 
 app = FastAPI()
+
+STATIC_DIR = os.path.join(os.path.dirname(__file__), "static")
+os.makedirs(STATIC_DIR, exist_ok=True)
+app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
 app.add_middleware(
     CORSMiddleware,

--- a/backend-app/models/worker.py
+++ b/backend-app/models/worker.py
@@ -9,6 +9,7 @@ class WorkerBase(SQLModel):
     name: str
     parental_surname: str
     maternal_surname: str
+    photo_url: Optional[str] = None
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
 
@@ -26,3 +27,4 @@ class WorkerUpdate(SQLModel):
     name: Optional[str] = None
     parental_surname: Optional[str] = None
     maternal_surname: Optional[str] = None
+    photo_url: Optional[str] = None

--- a/frontend-app/openapi.json
+++ b/frontend-app/openapi.json
@@ -1,1 +1,1747 @@
-{"openapi":"3.1.0","info":{"title":"FastAPI","version":"0.1.0"},"paths":{"/api/dev/create-db-and-tables":{"post":{"tags":["Development"],"summary":"Create Db And Tables","operationId":"create_db_and_tables_api_dev_create_db_and_tables_post","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}}}}},"/api/dev/reset-db":{"post":{"tags":["Development"],"summary":"Reset Database","operationId":"reset_database_api_dev_reset_db_post","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{}}}}}}},"/api/workers/":{"get":{"tags":["Workers"],"summary":"Get Workers","operationId":"getWorkers","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"items":{"$ref":"#/components/schemas/WorkerResponse"},"type":"array","title":"Response Getworkers"}}}}}},"post":{"tags":["Workers"],"summary":"Create Worker","operationId":"createWorker","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/WorkerCreate"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/WorkerResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/workers/{worker_id}":{"get":{"tags":["Workers"],"summary":"Get Worker","operationId":"getWorker","parameters":[{"name":"worker_id","in":"path","required":true,"schema":{"type":"integer","title":"Worker Id"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/WorkerResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"put":{"tags":["Workers"],"summary":"Update Worker","operationId":"updateWorker","parameters":[{"name":"worker_id","in":"path","required":true,"schema":{"type":"integer","title":"Worker Id"}}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/WorkerUpdate"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/WorkerResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"delete":{"tags":["Workers"],"summary":"Delete Worker","operationId":"deleteWorker","parameters":[{"name":"worker_id","in":"path","required":true,"schema":{"type":"integer","title":"Worker Id"}}],"responses":{"204":{"description":"Successful Response"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/clients/":{"get":{"tags":["Clients"],"summary":"Get Clients","operationId":"getClients","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"items":{"$ref":"#/components/schemas/ClientResponse"},"type":"array","title":"Response Getclients"}}}}}},"post":{"tags":["Clients"],"summary":"Create Client","operationId":"createClient","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/ClientCreate"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/ClientResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/projects/":{"get":{"tags":["Projects"],"summary":"Get Projects","operationId":"getProjects","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"items":{"$ref":"#/components/schemas/ProjectResponse"},"type":"array","title":"Response Getprojects"}}}}}},"post":{"tags":["Projects"],"summary":"Create Project","operationId":"createProject","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/ProjectCreate"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/ProjectResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/projects/{project_id}":{"get":{"tags":["Projects"],"summary":"Get Project","operationId":"getProject","parameters":[{"name":"project_id","in":"path","required":true,"schema":{"type":"integer","title":"Project Id"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/ProjectResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"put":{"tags":["Projects"],"summary":"Update Project","operationId":"updateProject","parameters":[{"name":"project_id","in":"path","required":true,"schema":{"type":"integer","title":"Project Id"}}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/ProjectUpdate"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/ProjectResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"delete":{"tags":["Projects"],"summary":"Delete Project","operationId":"deleteProject","parameters":[{"name":"project_id","in":"path","required":true,"schema":{"type":"integer","title":"Project Id"}}],"responses":{"204":{"description":"Successful Response"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/projects/newcomment":{"post":{"tags":["Projects"],"summary":"Create Comment","operationId":"createComment","parameters":[{"name":"project_id","in":"query","required":true,"schema":{"type":"integer","title":"Project Id"}}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/CommentCreate"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/CommentResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/projects/comments":{"get":{"tags":["Projects"],"summary":"Get Comments","operationId":"getComments","parameters":[{"name":"project_id","in":"query","required":true,"schema":{"type":"integer","title":"Project Id"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"type":"array","items":{"$ref":"#/components/schemas/CommentResponse"},"title":"Response Getcomments"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/projects/comment/{comment_id}":{"get":{"tags":["Projects"],"summary":"Get Comment","operationId":"getComment","parameters":[{"name":"comment_id","in":"path","required":true,"schema":{"type":"integer","title":"Comment Id"}},{"name":"project_id","in":"query","required":true,"schema":{"type":"integer","title":"Project Id"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/CommentResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"put":{"tags":["Projects"],"summary":"Update Comment","operationId":"updateComment","parameters":[{"name":"comment_id","in":"path","required":true,"schema":{"type":"integer","title":"Comment Id"}},{"name":"project_id","in":"query","required":true,"schema":{"type":"integer","title":"Project Id"}}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/CommentUpdate"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/CommentResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"delete":{"tags":["Projects"],"summary":"Delete Comment","operationId":"deleteComment","parameters":[{"name":"comment_id","in":"path","required":true,"schema":{"type":"integer","title":"Comment Id"}},{"name":"project_id","in":"query","required":true,"schema":{"type":"integer","title":"Project Id"}}],"responses":{"204":{"description":"Successful Response"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/projects/newstatus":{"post":{"tags":["Projects"],"summary":"Create Status","operationId":"createStatus","requestBody":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/StatusCreate"}}},"required":true},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/StatusResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}},"/api/projects/statuses":{"get":{"tags":["Projects"],"summary":"Get Statuses","operationId":"getStatuses","responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"items":{"$ref":"#/components/schemas/StatusResponse"},"type":"array","title":"Response Getstatuses"}}}}}}},"/api/projects/status/{status_id}":{"get":{"tags":["Projects"],"summary":"Get Status","operationId":"getStatus","parameters":[{"name":"status_id","in":"path","required":true,"schema":{"type":"integer","title":"Status Id"}}],"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/StatusResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"put":{"tags":["Projects"],"summary":"Update Status","operationId":"updateStatus","parameters":[{"name":"status_id","in":"path","required":true,"schema":{"type":"integer","title":"Status Id"}}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/StatusUpdate"}}}},"responses":{"200":{"description":"Successful Response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/StatusResponse"}}}},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}},"delete":{"tags":["Projects"],"summary":"Delete Status","operationId":"deleteStatus","parameters":[{"name":"status_id","in":"path","required":true,"schema":{"type":"integer","title":"Status Id"}}],"responses":{"204":{"description":"Successful Response"},"422":{"description":"Validation Error","content":{"application/json":{"schema":{"$ref":"#/components/schemas/HTTPValidationError"}}}}}}}},"components":{"schemas":{"ClientCreate":{"properties":{"name":{"type":"string","title":"Name"},"score":{"type":"integer","title":"Score"},"create_at":{"type":"string","format":"date-time","title":"Create At"},"updated_at":{"type":"string","format":"date-time","title":"Updated At"}},"type":"object","required":["name","score"],"title":"ClientCreate"},"ClientResponse":{"properties":{"name":{"type":"string","title":"Name"},"score":{"type":"integer","title":"Score"},"create_at":{"type":"string","format":"date-time","title":"Create At"},"updated_at":{"type":"string","format":"date-time","title":"Updated At"},"id":{"type":"integer","title":"Id"}},"type":"object","required":["name","score","id"],"title":"ClientResponse"},"CommentCreate":{"properties":{"project_id":{"type":"integer","title":"Project Id"},"date":{"type":"string","format":"date-time","title":"Date"},"comment":{"type":"string","title":"Comment"}},"type":"object","required":["project_id","comment"],"title":"CommentCreate"},"CommentResponse":{"properties":{"project_id":{"type":"integer","title":"Project Id"},"date":{"type":"string","format":"date-time","title":"Date"},"comment":{"type":"string","title":"Comment"},"id":{"type":"integer","title":"Id"}},"type":"object","required":["project_id","comment","id"],"title":"CommentResponse"},"CommentUpdate":{"properties":{"project_id":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Project Id"},"date":{"anyOf":[{"type":"string","format":"date-time"},{"type":"null"}],"title":"Date"},"comment":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Comment"}},"type":"object","title":"CommentUpdate"},"HTTPValidationError":{"properties":{"detail":{"items":{"$ref":"#/components/schemas/ValidationError"},"type":"array","title":"Detail"}},"type":"object","title":"HTTPValidationError"},"ProjectCreate":{"properties":{"name":{"type":"string","title":"Name"},"client_id":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Client Id"},"worker_id":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Worker Id"},"status_id":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Status Id"},"purchase_order":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Purchase Order"},"folio":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Folio"},"type":{"anyOf":[{"$ref":"#/components/schemas/ProjectType"},{"type":"null"}]},"start_date":{"anyOf":[{"type":"string","format":"date-time"},{"type":"null"}],"title":"Start Date"},"end_date":{"anyOf":[{"type":"string","format":"date-time"},{"type":"null"}],"title":"End Date"},"directory_path":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Directory Path"},"created_at":{"type":"string","format":"date-time","title":"Created At"},"updated_at":{"type":"string","format":"date-time","title":"Updated At"}},"type":"object","required":["name"],"title":"ProjectCreate"},"ProjectResponse":{"properties":{"name":{"type":"string","title":"Name"},"client_id":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Client Id"},"worker_id":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Worker Id"},"status_id":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Status Id"},"purchase_order":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Purchase Order"},"folio":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Folio"},"type":{"anyOf":[{"$ref":"#/components/schemas/ProjectType"},{"type":"null"}]},"start_date":{"anyOf":[{"type":"string","format":"date-time"},{"type":"null"}],"title":"Start Date"},"end_date":{"anyOf":[{"type":"string","format":"date-time"},{"type":"null"}],"title":"End Date"},"directory_path":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Directory Path"},"created_at":{"type":"string","format":"date-time","title":"Created At"},"updated_at":{"type":"string","format":"date-time","title":"Updated At"},"id":{"type":"integer","title":"Id"}},"type":"object","required":["name","id"],"title":"ProjectResponse"},"ProjectType":{"type":"string","enum":["Project","Supply","Additional","Other"],"title":"ProjectType"},"ProjectUpdate":{"properties":{"name":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Name"},"client_id":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Client Id"},"worker_id":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Worker Id"},"status_id":{"anyOf":[{"type":"integer"},{"type":"null"}],"title":"Status Id"},"purchase_order":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Purchase Order"},"folio":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Folio"},"type":{"anyOf":[{"$ref":"#/components/schemas/ProjectType"},{"type":"null"}]},"start_date":{"anyOf":[{"type":"string","format":"date-time"},{"type":"null"}],"title":"Start Date"},"end_date":{"anyOf":[{"type":"string","format":"date-time"},{"type":"null"}],"title":"End Date"},"directory_path":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Directory Path"}},"type":"object","title":"ProjectUpdate"},"StatusCreate":{"properties":{"name":{"type":"string","title":"Name"}},"type":"object","required":["name"],"title":"StatusCreate"},"StatusResponse":{"properties":{"name":{"type":"string","title":"Name"},"id":{"type":"integer","title":"Id"}},"type":"object","required":["name","id"],"title":"StatusResponse"},"StatusUpdate":{"properties":{"name":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Name"}},"type":"object","title":"StatusUpdate"},"ValidationError":{"properties":{"loc":{"items":{"anyOf":[{"type":"string"},{"type":"integer"}]},"type":"array","title":"Location"},"msg":{"type":"string","title":"Message"},"type":{"type":"string","title":"Error Type"}},"type":"object","required":["loc","msg","type"],"title":"ValidationError"},"WorkerCreate":{"properties":{"name":{"type":"string","title":"Name"},"parental_surname":{"type":"string","title":"Parental Surname"},"maternal_surname":{"type":"string","title":"Maternal Surname"},"created_at":{"type":"string","format":"date-time","title":"Created At"},"updated_at":{"type":"string","format":"date-time","title":"Updated At"}},"type":"object","required":["name","parental_surname","maternal_surname"],"title":"WorkerCreate"},"WorkerResponse":{"properties":{"name":{"type":"string","title":"Name"},"parental_surname":{"type":"string","title":"Parental Surname"},"maternal_surname":{"type":"string","title":"Maternal Surname"},"created_at":{"type":"string","format":"date-time","title":"Created At"},"updated_at":{"type":"string","format":"date-time","title":"Updated At"},"id":{"type":"integer","title":"Id"}},"type":"object","required":["name","parental_surname","maternal_surname","id"],"title":"WorkerResponse"},"WorkerUpdate":{"properties":{"name":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Name"},"parental_surname":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Parental Surname"},"maternal_surname":{"anyOf":[{"type":"string"},{"type":"null"}],"title":"Maternal Surname"}},"type":"object","title":"WorkerUpdate"}}}}
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "FastAPI",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/api/dev/create-db-and-tables": {
+      "post": {
+        "tags": [
+          "Development"
+        ],
+        "summary": "Create Db And Tables",
+        "operationId": "create_db_and_tables_api_dev_create_db_and_tables_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/dev/reset-db": {
+      "post": {
+        "tags": [
+          "Development"
+        ],
+        "summary": "Reset Database",
+        "operationId": "reset_database_api_dev_reset_db_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workers/": {
+      "get": {
+        "tags": [
+          "Workers"
+        ],
+        "summary": "Get Workers",
+        "operationId": "getWorkers",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/WorkerResponse"
+                  },
+                  "type": "array",
+                  "title": "Response Getworkers"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Workers"
+        ],
+        "summary": "Create Worker",
+        "operationId": "createWorker",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkerCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkerResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workers/{worker_id}": {
+      "get": {
+        "tags": [
+          "Workers"
+        ],
+        "summary": "Get Worker",
+        "operationId": "getWorker",
+        "parameters": [
+          {
+            "name": "worker_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Worker Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkerResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Workers"
+        ],
+        "summary": "Update Worker",
+        "operationId": "updateWorker",
+        "parameters": [
+          {
+            "name": "worker_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Worker Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkerUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkerResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Workers"
+        ],
+        "summary": "Delete Worker",
+        "operationId": "deleteWorker",
+        "parameters": [
+          {
+            "name": "worker_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Worker Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/clients/": {
+      "get": {
+        "tags": [
+          "Clients"
+        ],
+        "summary": "Get Clients",
+        "operationId": "getClients",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ClientResponse"
+                  },
+                  "type": "array",
+                  "title": "Response Getclients"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Clients"
+        ],
+        "summary": "Create Client",
+        "operationId": "createClient",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ClientCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/projects/": {
+      "get": {
+        "tags": [
+          "Projects"
+        ],
+        "summary": "Get Projects",
+        "operationId": "getProjects",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ProjectResponse"
+                  },
+                  "type": "array",
+                  "title": "Response Getprojects"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Projects"
+        ],
+        "summary": "Create Project",
+        "operationId": "createProject",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProjectCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/projects/{project_id}": {
+      "get": {
+        "tags": [
+          "Projects"
+        ],
+        "summary": "Get Project",
+        "operationId": "getProject",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Project Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Projects"
+        ],
+        "summary": "Update Project",
+        "operationId": "updateProject",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Project Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProjectUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Projects"
+        ],
+        "summary": "Delete Project",
+        "operationId": "deleteProject",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Project Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/projects/newcomment": {
+      "post": {
+        "tags": [
+          "Projects"
+        ],
+        "summary": "Create Comment",
+        "operationId": "createComment",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Project Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CommentCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommentResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/projects/comments": {
+      "get": {
+        "tags": [
+          "Projects"
+        ],
+        "summary": "Get Comments",
+        "operationId": "getComments",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Project Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CommentResponse"
+                  },
+                  "title": "Response Getcomments"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/projects/comment/{comment_id}": {
+      "get": {
+        "tags": [
+          "Projects"
+        ],
+        "summary": "Get Comment",
+        "operationId": "getComment",
+        "parameters": [
+          {
+            "name": "comment_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Comment Id"
+            }
+          },
+          {
+            "name": "project_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Project Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommentResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Projects"
+        ],
+        "summary": "Update Comment",
+        "operationId": "updateComment",
+        "parameters": [
+          {
+            "name": "comment_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Comment Id"
+            }
+          },
+          {
+            "name": "project_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Project Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CommentUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommentResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Projects"
+        ],
+        "summary": "Delete Comment",
+        "operationId": "deleteComment",
+        "parameters": [
+          {
+            "name": "comment_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Comment Id"
+            }
+          },
+          {
+            "name": "project_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Project Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/projects/newstatus": {
+      "post": {
+        "tags": [
+          "Projects"
+        ],
+        "summary": "Create Status",
+        "operationId": "createStatus",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StatusCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/projects/statuses": {
+      "get": {
+        "tags": [
+          "Projects"
+        ],
+        "summary": "Get Statuses",
+        "operationId": "getStatuses",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/StatusResponse"
+                  },
+                  "type": "array",
+                  "title": "Response Getstatuses"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/projects/status/{status_id}": {
+      "get": {
+        "tags": [
+          "Projects"
+        ],
+        "summary": "Get Status",
+        "operationId": "getStatus",
+        "parameters": [
+          {
+            "name": "status_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Status Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Projects"
+        ],
+        "summary": "Update Status",
+        "operationId": "updateStatus",
+        "parameters": [
+          {
+            "name": "status_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Status Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StatusUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Projects"
+        ],
+        "summary": "Delete Status",
+        "operationId": "deleteStatus",
+        "parameters": [
+          {
+            "name": "status_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Status Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workers/{worker_id}/photo": {
+      "post": {
+        "tags": [
+          "Workers"
+        ],
+        "summary": "Upload Worker Photo",
+        "operationId": "uploadWorkerPhoto",
+        "parameters": [
+          {
+            "name": "worker_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Worker Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkerResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ClientCreate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "score": {
+            "type": "integer",
+            "title": "Score"
+          },
+          "create_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Create At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "score"
+        ],
+        "title": "ClientCreate"
+      },
+      "ClientResponse": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "score": {
+            "type": "integer",
+            "title": "Score"
+          },
+          "create_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Create At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          },
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "score",
+          "id"
+        ],
+        "title": "ClientResponse"
+      },
+      "CommentCreate": {
+        "properties": {
+          "project_id": {
+            "type": "integer",
+            "title": "Project Id"
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Date"
+          },
+          "comment": {
+            "type": "string",
+            "title": "Comment"
+          }
+        },
+        "type": "object",
+        "required": [
+          "project_id",
+          "comment"
+        ],
+        "title": "CommentCreate"
+      },
+      "CommentResponse": {
+        "properties": {
+          "project_id": {
+            "type": "integer",
+            "title": "Project Id"
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Date"
+          },
+          "comment": {
+            "type": "string",
+            "title": "Comment"
+          },
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "project_id",
+          "comment",
+          "id"
+        ],
+        "title": "CommentResponse"
+      },
+      "CommentUpdate": {
+        "properties": {
+          "project_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Project Id"
+          },
+          "date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Date"
+          },
+          "comment": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Comment"
+          }
+        },
+        "type": "object",
+        "title": "CommentUpdate"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "ProjectCreate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "client_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Id"
+          },
+          "worker_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Worker Id"
+          },
+          "status_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status Id"
+          },
+          "purchase_order": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Purchase Order"
+          },
+          "folio": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Folio"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ProjectType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "start_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Date"
+          },
+          "end_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End Date"
+          },
+          "directory_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Directory Path"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "ProjectCreate"
+      },
+      "ProjectResponse": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "client_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Id"
+          },
+          "worker_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Worker Id"
+          },
+          "status_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status Id"
+          },
+          "purchase_order": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Purchase Order"
+          },
+          "folio": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Folio"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ProjectType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "start_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Date"
+          },
+          "end_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End Date"
+          },
+          "directory_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Directory Path"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          },
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "id"
+        ],
+        "title": "ProjectResponse"
+      },
+      "ProjectType": {
+        "type": "string",
+        "enum": [
+          "Project",
+          "Supply",
+          "Additional",
+          "Other"
+        ],
+        "title": "ProjectType"
+      },
+      "ProjectUpdate": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "client_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Id"
+          },
+          "worker_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Worker Id"
+          },
+          "status_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status Id"
+          },
+          "purchase_order": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Purchase Order"
+          },
+          "folio": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Folio"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ProjectType"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "start_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Date"
+          },
+          "end_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End Date"
+          },
+          "directory_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Directory Path"
+          }
+        },
+        "type": "object",
+        "title": "ProjectUpdate"
+      },
+      "StatusCreate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "StatusCreate"
+      },
+      "StatusResponse": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "id"
+        ],
+        "title": "StatusResponse"
+      },
+      "StatusUpdate": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          }
+        },
+        "type": "object",
+        "title": "StatusUpdate"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      },
+      "WorkerCreate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "parental_surname": {
+            "type": "string",
+            "title": "Parental Surname"
+          },
+          "maternal_surname": {
+            "type": "string",
+            "title": "Maternal Surname"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          },
+          "photo_url": {
+            "type": "string",
+            "title": "Photo Url",
+            "nullable": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "parental_surname",
+          "maternal_surname"
+        ],
+        "title": "WorkerCreate"
+      },
+      "WorkerResponse": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "parental_surname": {
+            "type": "string",
+            "title": "Parental Surname"
+          },
+          "maternal_surname": {
+            "type": "string",
+            "title": "Maternal Surname"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          },
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "photo_url": {
+            "type": "string",
+            "title": "Photo Url",
+            "nullable": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "parental_surname",
+          "maternal_surname",
+          "id"
+        ],
+        "title": "WorkerResponse"
+      },
+      "WorkerUpdate": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "parental_surname": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parental Surname"
+          },
+          "maternal_surname": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Maternal Surname"
+          },
+          "photo_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Photo Url"
+          }
+        },
+        "type": "object",
+        "title": "WorkerUpdate"
+      }
+    }
+  }
+}

--- a/frontend-app/src/api/fastAPI.schemas.ts
+++ b/frontend-app/src/api/fastAPI.schemas.ts
@@ -186,6 +186,7 @@ export interface WorkerCreate {
   name: string;
   parental_surname: string;
   maternal_surname: string;
+  photo_url?: string | null;
   created_at?: string;
   updated_at?: string;
 }
@@ -194,6 +195,7 @@ export interface WorkerResponse {
   name: string;
   parental_surname: string;
   maternal_surname: string;
+  photo_url?: string | null;
   created_at?: string;
   updated_at?: string;
   id: number;
@@ -209,6 +211,7 @@ export interface WorkerUpdate {
   name?: WorkerUpdateName;
   parental_surname?: WorkerUpdateParentalSurname;
   maternal_surname?: WorkerUpdateMaternalSurname;
+  photo_url?: string | null;
 }
 
 export type CreateCommentParams = {

--- a/frontend-app/src/api/fastAPI.ts
+++ b/frontend-app/src/api/fastAPI.ts
@@ -1778,4 +1778,18 @@ export const useDeleteStatus = <TError = AxiosError<HTTPValidationError>,
 
       return useMutation(mutationOptions , queryClient);
     }
+
+// Custom helper to upload a worker photo
+export const uploadWorkerPhoto = (
+  workerId: number,
+  file: File,
+  options?: AxiosRequestConfig,
+): Promise<AxiosResponse<WorkerResponse>> => {
+  const formData = new FormData();
+  formData.append('file', file);
+  return axios.default.post(`/api/workers/${workerId}/photo`, formData, {
+    headers: { 'Content-Type': 'multipart/form-data', ...(options?.headers ?? {}) },
+    ...options,
+  });
+};
     

--- a/frontend-app/src/components/WorkerList.tsx
+++ b/frontend-app/src/components/WorkerList.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef } from 'react'
+import { useLayoutEffect, useRef, useState, type ChangeEvent } from 'react'
 import { yupResolver } from '@hookform/resolvers/yup'
 import clsx from 'clsx'
 import { useForm } from 'react-hook-form'
@@ -6,6 +6,7 @@ import * as yup from 'yup'
 import {
   useGetWorkers,
   useCreateWorker,
+  uploadWorkerPhoto,
 } from '../api/fastAPI'
 import type { WorkerCreate } from '../api/fastAPI.schemas'
 import {
@@ -27,6 +28,7 @@ export function WorkerList() {
   const { data, refetch } = useGetWorkers()
   const createWorker = useCreateWorker()
   const modalRef = useRef<ModalRef>(null)
+  const [photo, setPhoto] = useState<File | null>(null)
 
   const validationSchema = yup.object({
     name: yup.string().required('El nombre es requerido'),
@@ -47,7 +49,7 @@ export function WorkerList() {
   } = useForm<WorkerCreate>({
     mode: 'all',
     reValidateMode: 'onChange',
-    defaultValues: { name: '', parental_surname: '', maternal_surname: '' },
+    defaultValues: { name: '', parental_surname: '', maternal_surname: '', photo_url: undefined },
     resolver: yupResolver(validationSchema),
   })
 
@@ -59,7 +61,11 @@ export function WorkerList() {
     createWorker.mutate(
       { data },
       {
-        onSuccess: () => {
+        onSuccess: async res => {
+          if (photo) {
+            await uploadWorkerPhoto(res.data.id, photo)
+          }
+          setPhoto(null)
           modalRef.current?.close(null)
           refetch()
         },
@@ -72,6 +78,10 @@ export function WorkerList() {
   ) => {
     const value = event.detail?.value ?? event.target.value
     setValue(field, value, { shouldValidate: true })
+  }
+
+  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setPhoto(e.target.files?.[0] ?? null)
   }
 
   const openModal = () => {
@@ -104,6 +114,7 @@ export function WorkerList() {
                   className={clsx({ 'ix-invalid': errors.maternal_surname })}
                   invalidText={errors.maternal_surname?.message}
                 />
+                <input type="file" onChange={handleFileChange} />
               </IxLayoutAuto>
             </form>
           </IxModalContent>
@@ -136,6 +147,9 @@ export function WorkerList() {
         {workers.map(w => (
           <IxCard key={w.id} variant="outline">
             <IxCardContent>
+              {w.photo_url && (
+                <img src={w.photo_url} style={{ width: '100%', height: 'auto' }} />
+              )}
               <IxTypography bold>{w.name}</IxTypography>
               <IxTypography>{w.parental_surname} {w.maternal_surname}</IxTypography>
               <IxTypography text-color="alarm">ID: {w.id}</IxTypography>


### PR DESCRIPTION
## Summary
- add `photo_url` field to workers
- mount static directory for uploads
- support uploading a photo to a worker through new endpoint
- expose helper in frontend API
- allow user to select a photo when creating a worker and show it
- update OpenAPI and generated schemas

## Testing
- `python -m py_compile backend-app/**/*.py`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_68672b0200448320b53d3df19f754a28